### PR TITLE
Fix EntityTossedItem initialization issue on Fabric

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityTossedItem.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityTossedItem.java
@@ -14,6 +14,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
@@ -26,6 +27,9 @@ import net.neoforged.api.distmarker.OnlyIn;
 public class EntityTossedItem extends ThrowableItemProjectile {
 
     protected static final EntityDataAccessor<Boolean> DART = SynchedEntityData.defineId(EntityTossedItem.class, EntityDataSerializers.BOOLEAN);
+
+    public static final Item DEFAULT_ITEM = Items.COBBLESTONE;
+
 
     public EntityTossedItem(EntityType p_i50154_1_, Level p_i50154_2_) {
         super(p_i50154_1_, p_i50154_2_);
@@ -53,6 +57,7 @@ public class EntityTossedItem extends ThrowableItemProjectile {
 
     public void setDart(boolean dart) {
         this.entityData.set(DART, dart);
+        this.setItem(new ItemStack(getDartItem(dart)));
     }
 
     // getAddEntityPacket is no longer needed in 1.21
@@ -132,11 +137,15 @@ public class EntityTossedItem extends ThrowableItemProjectile {
         }
     }
 
+    @Override
     protected Item getDefaultItem() {
-        // entityData may be null during initialization when parent class calls this
-        if (this.entityData != null && isDart()) {
+        return DEFAULT_ITEM;
+    }
+
+    private static Item getDartItem(boolean dart) {
+        if (dart)
             return AMItemRegistry.ANCIENT_DART.get();
-        }
-        return Items.COBBLESTONE;
+
+        return DEFAULT_ITEM;
     }
 }


### PR DESCRIPTION
## Summary

This changes how `EntityTossedItem` determines its projectile item in order to avoid initialization-related issues on Fabric.

Previously, `getDefaultItem()` attempted to return different items depending on `isDart()`:

```java
if (this.entityData != null && isDart()) {
    return AMItemRegistry.ANCIENT_DART.get();
}
```

However, the null-check intended to guard early initialization does not reliably prevent the issue in practice, as the compiler/runtime appears to optimize the condition away or otherwise treat it as unnecessary. This can result in `isDart()` being evaluated during initialization when synced entity data is not yet in a valid state.

```java
protected class_1792 method_16942() {
    return isDart() ? AMItemRegistry.ANCIENT_DART : class_1802.field_20412;
}
```

## Changes

* Make `getDefaultItem()` return a stable fallback item
* Update the projectile `ItemStack` when the dart state changes instead of dynamically resolving it through `getDefaultItem()`

## Why

`ThrowableItemProjectile#getDefaultItem()` appears to work more reliably when treated as a constant fallback provider rather than a state-dependent resolver.

Since the projectile already supports changing its synced `ItemStack`, it is safer to update the item directly when the dart boolean changes instead of relying on runtime checks inside `getDefaultItem()`.

## Notes

A cleaner long-term approach would likely be separating the dart and cobblestone behavior into different projectile entity classes entirely. However, this patch aims to stabilize the current implementation with minimal code changes and minimal behavioral impact.

I have not tested this change in-game.
